### PR TITLE
1.55.5 - Prevent multiple initial calls on initialParseId in MealCreateScreen

### DIFF
--- a/lib/screens/meal_create/meal_create_screen.dart
+++ b/lib/screens/meal_create/meal_create_screen.dart
@@ -45,6 +45,7 @@ class MealCreateScreen extends ConsumerStatefulWidget {
 
 class _MealCreateScreenState extends ConsumerState<MealCreateScreen> {
   bool _mealSaved = false;
+  bool _isFirstCall = true;
   final ScrollController _scrollController = ScrollController();
 
   late bool _isCreatingMeal;
@@ -85,15 +86,19 @@ class _MealCreateScreenState extends ConsumerState<MealCreateScreen> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _initialParseId().then((meal) {
-      if (meal != null) {
-        BasicUtils.afterBuild(() {
-          ref.read(_$meal.notifier).state = meal;
-          _onSourceTextChange(_sourceController.text);
-        });
-      }
-      ref.read(_$isLoading.notifier).state = false;
-    });
+
+    if (_isFirstCall) {
+      _isFirstCall = false;
+      _initialParseId().then((meal) {
+        if (meal != null) {
+          BasicUtils.afterBuild(() {
+            ref.read(_$meal.notifier).state = meal;
+            _onSourceTextChange(_sourceController.text);
+          });
+        }
+        ref.read(_$isLoading.notifier).state = false;
+      });
+    }
   }
 
   @override


### PR DESCRIPTION
### Features
- ...

### Fixed bugs
- [Prevent multiple initial calls on _initialParseId in MealCreateScreen](https://github.com/LucasG04/foodly_app/commit/b833c2e0574e7b456e1cd5374b3471f56794290a)

### Further improvements
- ...

### Checklist
- [x] Flutter version upgraded/checked
