### PR TITLE
1.55.16 - Use hive_flutter, adds mounted check and better logging

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,11 +10,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localized_locales/flutter_localized_locales.dart';
 import 'package:flutter_phoenix/flutter_phoenix.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 import 'package:internet_connection_checker/internet_connection_checker.dart';
 import 'package:logging/logging.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:uni_links/uni_links.dart';
 
@@ -91,8 +90,7 @@ void main() {
 }
 
 Future<void> initializeHive() async {
-  final dir = await getApplicationDocumentsDirectory();
-  Hive.init(dir.path);
+  await Hive.initFlutter();
   Hive.registerAdapter(LinkMetadataAdapter());
   await Future.wait<dynamic>([
     SettingsService.initialize(),

--- a/lib/models/link_metadata.dart
+++ b/lib/models/link_metadata.dart
@@ -1,4 +1,4 @@
-import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 
 part 'link_metadata.g.dart';
 

--- a/lib/screens/meal/meal_screen.dart
+++ b/lib/screens/meal/meal_screen.dart
@@ -583,7 +583,9 @@ class _MealScreenState extends ConsumerState<MealScreen> with DisposableWidget {
   Future<void> _fetchStats() async {
     final result =
         await MealStatService.getStat(ref.read(planProvider)!.id!, widget.id);
-    ref.read(_$mealStat.notifier).state = result;
+    if (mounted) {
+      ref.read(_$mealStat.notifier).state = result;
+    }
   }
 
   void _checkOwnerOfMeal() {

--- a/lib/services/app_review_service.dart
+++ b/lib/services/app_review_service.dart
@@ -1,4 +1,4 @@
-import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 import 'package:in_app_review/in_app_review.dart';
 
 class AppReviewService {

--- a/lib/services/image_cache_manager.dart
+++ b/lib/services/image_cache_manager.dart
@@ -1,7 +1,7 @@
 import 'dart:collection';
 import 'dart:typed_data';
 
-import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 
 class ImageCacheManager {
   ImageCacheManager._();

--- a/lib/services/link_metadata_service.dart
+++ b/lib/services/link_metadata_service.dart
@@ -1,4 +1,4 @@
-import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:metadata_fetch/metadata_fetch.dart';
 

--- a/lib/services/plan_service.dart
+++ b/lib/services/plan_service.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 
 import '../constants.dart';

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/painting.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 
 import '../constants.dart';
 import '../models/plan_meal.dart';

--- a/lib/services/version_service.dart
+++ b/lib/services/version_service.dart
@@ -1,5 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 
 import '../models/foodly_version.dart';

--- a/lib/widgets/foodly_network_image.dart
+++ b/lib/widgets/foodly_network_image.dart
@@ -98,6 +98,7 @@ class _FoodlyNetworkImageState extends State<FoodlyNetworkImage> {
             child = _buildFallbackImage();
           } else if (snapshot.hasData) {
             child = Image.memory(
+              key: const ValueKey(0),
               snapshot.data!,
               fit: widget.boxFit,
               width: double.infinity,
@@ -117,6 +118,7 @@ class _FoodlyNetworkImageState extends State<FoodlyNetworkImage> {
   Image _buildFallbackImage() {
     return Image.asset(
       'assets/images/food_fallback.png',
+      key: const ValueKey(1),
       fit: widget.boxFit,
       width: double.infinity,
       height: double.infinity,
@@ -125,6 +127,7 @@ class _FoodlyNetworkImageState extends State<FoodlyNetworkImage> {
 
   SkeletonContainer _buildLoader() {
     return const SkeletonContainer(
+      key: ValueKey(2),
       width: double.infinity,
       height: double.infinity,
     );

--- a/lib/widgets/foodly_network_image.dart
+++ b/lib/widgets/foodly_network_image.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
 
 import '../services/image_cache_manager.dart';
 import '../services/storage_service.dart';
@@ -24,6 +25,7 @@ class FoodlyNetworkImage extends StatefulWidget {
 }
 
 class _FoodlyNetworkImageState extends State<FoodlyNetworkImage> {
+  final _log = Logger('FoodlyNetworkImage');
   final Dio _dio = Dio();
   late Future<Uint8List?> _imageFuture;
 
@@ -47,6 +49,7 @@ class _FoodlyNetworkImageState extends State<FoodlyNetworkImage> {
       if (storageUrl != null) {
         imageUrl = storageUrl;
       } else {
+        _log.severe('Storage URL could not be retrieved for $url');
         throw Exception('Storage URL could not be retrieved for $url');
       }
     }
@@ -65,7 +68,6 @@ class _FoodlyNetworkImageState extends State<FoodlyNetworkImage> {
         throw Exception('Failed to load image: ${response.statusCode}');
       }
     } catch (e) {
-      // Handle network errors gracefully
       throw Exception('Error loading image from $imageUrl: $e');
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -888,6 +888,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
+  hive_flutter:
+    dependency: "direct main"
+    description:
+      name: hive_flutter
+      sha256: dca1da446b1d808a51689fb5d0c6c9510c0a2ba01e22805d492c73b68e33eecc
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   hive_generator:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   auto_route: ^5.0.4
   intl: ^0.19.0
   hive: ^2.2.3
+  hive_flutter: ^1.1.0
   # flutter_cache_manager_hive:
   #   git:
   #     url: https://github.com/X-Wei/flutter_cache_manager_hive.git
@@ -112,7 +113,7 @@ dev_dependencies:
   # build runner via: `dart run build_runner build --delete-conflicting-outputs`
   build_runner: ^2.4.6
   auto_route_generator: ^5.0.3
-  hive_generator: ^2.0.0
+  hive_generator: ^2.0.1
   flutter_launcher_icons: ^0.9.0
   envied_generator: ^0.3.0+3
 


### PR DESCRIPTION
### Fixed bugs
- [adds mounted check before updating meal stat state](https://github.com/LucasG04/foodly_app/commit/c7aa1a6c09cf99cc3ddbfaab6287beb85a742b24)
- [updates Hive initialization to use hive_flutter and updates dependencies](https://github.com/LucasG04/foodly_app/commit/4ba42ae47f9308706cb2286fdfe384813fbf422f)

### Further improvements
- [adds logging for StorageService error handling in FoodlyNetworkImage](https://github.com/LucasG04/foodly_app/commit/a9758202b9fb8b464e486b64fc490d3c95bf98ca)

### Checklist
- [x] Flutter version checked/upgraded
- [x] Firebase SDK Version in `/ios/Podfile` checked/upgraded
