### PR TITLE
1.55.21 - Rewrites image cache manager to save strings instead of Uint8List

### DIFF
--- a/lib/services/image_cache_manager.dart
+++ b/lib/services/image_cache_manager.dart
@@ -1,6 +1,8 @@
 import 'dart:collection';
+import 'dart:convert'; // Für die Base64-Kodierung und -Dekodierung
 import 'dart:typed_data';
 
+import 'package:firebase_performance/firebase_performance.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 
@@ -14,13 +16,13 @@ class ImageCacheManager {
   static final LinkedHashMap<String, DateTime> accessTimeMap = LinkedHashMap();
 
   static Future<void> initialize() async {
-    const boxName = 'imageCache';
+    imageCache = await Hive.openBox('imageCache2');
+
+    // delete old image box
     try {
-      imageCache = await Hive.openBox(boxName);
+      await Hive.deleteBoxFromDisk('imageCache');
     } catch (e) {
-      _log.severe('Failed to open $boxName box: $e');
-      await Hive.deleteBoxFromDisk(boxName);
-      imageCache = await Hive.openBox(boxName);
+      _log.fine('Could not delete old imageCache box', e);
     }
   }
 
@@ -28,20 +30,26 @@ class ImageCacheManager {
     _evictExpiredItems(); // Evict expired items before returning the cached image
     if (imageCache.containsKey(url)) {
       accessTimeMap[url] = DateTime.now();
-      return imageCache.get(url);
+      final String base64String = imageCache.get(url);
+      return base64Decode(base64String);
     }
     return null;
   }
 
   static void put(String url, Uint8List imageBytes) {
+    final timeTrace =
+        FirebasePerformance.instance.newTrace('ImageCacheManager-put');
+    timeTrace.start();
     _evictExpiredItems(); // Evict expired items before adding a new one
 
     if (imageCache.length >= maxCacheSize) {
       _evictLRUItem(); // Evict LRU if cache is full
     }
 
-    imageCache.put(url, imageBytes);
+    final String base64String = base64Encode(imageBytes);
+    imageCache.put(url, base64String);
     accessTimeMap[url] = DateTime.now();
+    timeTrace.stop();
   }
 
   /// Evict the least recently used item

--- a/lib/services/image_cache_manager.dart
+++ b/lib/services/image_cache_manager.dart
@@ -1,5 +1,5 @@
 import 'dart:collection';
-import 'dart:convert'; // Für die Base64-Kodierung und -Dekodierung
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:firebase_performance/firebase_performance.dart';

--- a/lib/services/link_metadata_service.dart
+++ b/lib/services/link_metadata_service.dart
@@ -10,15 +10,11 @@ class LinkMetadataService {
   static final log = Logger('LinkMetadataService');
 
   static late Box<LinkMetadata> _dataBox;
-  static bool _isReady = false;
 
   static Future initialize() async {
     _dataBox = await Hive.openBox('linkmetadata');
-    _isReady = true;
     log.finer('initialized');
   }
-
-  static bool get isReady => _isReady;
 
   static Future<LinkMetadata?> get(String link) async {
     log.finer('Call getFromApi with $link');

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -12,20 +12,16 @@ class SettingsService {
   SettingsService._();
 
   static late Box _settingsBox;
-  static bool _isReady = false;
   static WidgetRef? _ref;
 
   static Future initialize() async {
     _settingsBox = await Hive.openBox<dynamic>('settings');
-    _isReady = true;
   }
 
   // ignore: use_setters_to_change_properties
   static void setRef(WidgetRef ref) {
     _ref = ref;
   }
-
-  static bool get isReady => _isReady;
 
   static bool get isFirstUsage =>
       _settingsBox.get('firstUsage', defaultValue: true) as bool;

--- a/lib/services/version_service.dart
+++ b/lib/services/version_service.dart
@@ -10,7 +10,6 @@ class VersionService {
   static final _log = Logger('ShoppingListService');
 
   static late Box _settingsBox;
-  static bool _isReady = false;
 
   static final CollectionReference<FoodlyVersion> _firestore = FirebaseFirestore
       .instance
@@ -23,10 +22,7 @@ class VersionService {
   static Future initialize() async {
     _log.fine('Initializing');
     _settingsBox = await Hive.openBox<dynamic>('verison');
-    _isReady = true;
   }
-
-  static bool get isReady => _isReady;
 
   static String? get lastCheckedVersion =>
       _settingsBox.get('lastCheckedVersion') as String?;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   flutter_riverpod: ^2.1.1
   auto_route: ^5.0.4
   intl: ^0.19.0
+  # see hive_ce for continued support; can't upgrade because of https://github.com/petercinibulk/envied/issues/125
   hive: ^2.2.3
   hive_flutter: ^1.1.0
   # flutter_cache_manager_hive:


### PR DESCRIPTION
### Fixed bugs
- [rewrites image cache manager to save strings instead of Uint8List](https://github.com/LucasG04/foodly_app/commit/2721a0240710c2f99f89bac09a5a2ecab54cafa7)

### Checklist
- [x] Flutter version checked/upgraded
- [x] Firebase SDK Version in `/ios/Podfile` checked/upgraded
