### PR TITLE
1.55.22 - Adjustments network image cache

### DIFF
--- a/lib/services/image_cache_manager.dart
+++ b/lib/services/image_cache_manager.dart
@@ -1,5 +1,4 @@
 import 'dart:collection';
-import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:firebase_performance/firebase_performance.dart';
@@ -17,17 +16,17 @@ class ImageCacheManager {
 
   static Future<void> initialize() async {
     try {
-      imageCache = await Hive.openBox('imageCache2');
+      imageCache = await Hive.openBox('imageCache');
     } catch (e) {
-      await Hive.deleteBoxFromDisk('imageCache2');
-      _log.severe('Could not open imageCache2 box', e);
+      await Hive.deleteBoxFromDisk('imageCache');
+      _log.severe('Could not open imageCache box', e);
     } finally {
-      imageCache = await Hive.openBox('imageCache2');
+      imageCache = await Hive.openBox('imageCache');
     }
 
     // delete old image box
     try {
-      await Hive.deleteBoxFromDisk('imageCache');
+      await Hive.deleteBoxFromDisk('imageCache2');
     } catch (e) {
       _log.fine('Could not delete old imageCache box', e);
     }
@@ -37,8 +36,7 @@ class ImageCacheManager {
     _evictExpiredItems(); // Evict expired items before returning the cached image
     if (imageCache.containsKey(url)) {
       accessTimeMap[url] = DateTime.now();
-      final String base64String = imageCache.get(url);
-      return base64Decode(base64String);
+      return imageCache.get(url);
     }
     return null;
   }
@@ -53,8 +51,7 @@ class ImageCacheManager {
       _evictLRUItem(); // Evict LRU if cache is full
     }
 
-    final String base64String = base64Encode(imageBytes);
-    imageCache.put(url, base64String);
+    imageCache.put(url, imageBytes);
     accessTimeMap[url] = DateTime.now();
     timeTrace.stop();
   }

--- a/lib/services/image_cache_manager.dart
+++ b/lib/services/image_cache_manager.dart
@@ -16,7 +16,14 @@ class ImageCacheManager {
   static final LinkedHashMap<String, DateTime> accessTimeMap = LinkedHashMap();
 
   static Future<void> initialize() async {
-    imageCache = await Hive.openBox('imageCache2');
+    try {
+      imageCache = await Hive.openBox('imageCache2');
+    } catch (e) {
+      await Hive.deleteBoxFromDisk('imageCache2');
+      _log.severe('Could not open imageCache2 box', e);
+    } finally {
+      imageCache = await Hive.openBox('imageCache2');
+    }
 
     // delete old image box
     try {


### PR DESCRIPTION
### Fixed bugs
- [fix: handle errors when opening imageCache2 box and ensure it is recr…](https://github.com/LucasG04/foodly_app/commit/ba6be5af5e47cc6ef19ae6a846eb2dd9b2a4c9b7)

### Further improvements
- [revert: save Uint8List instead of strings](https://github.com/LucasG04/foodly_app/commit/4cea2924c6a7b7abf61300ace50dd855d437d2a2)
- [refactor: image cache usage of encoded url keys](https://github.com/LucasG04/foodly_app/commit/26a8ad04074e6b1ac5ca13230f72a20b2540e3d3)

### Checklist
- [x] Flutter version checked/upgraded
- [x] Firebase SDK Version in `/ios/Podfile` checked/upgraded
