### PR TITLE
1.55.28 - Release #363 and fix Gemfile.lock

### DIFF
--- a/android/Gemfile.lock
+++ b/android/Gemfile.lock
@@ -216,10 +216,12 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
   fastlane
   fastlane-plugin-flutter_version!
 
 BUNDLED WITH
-   2.3.11
+   2.5.11


### PR DESCRIPTION
- Release #363 
- [fix: update Gemfile.lock to include action platform](https://github.com/LucasG04/foodly_app/commit/6e9e2c43391d4a07eb3f9575c7c10753af47a2eb) 